### PR TITLE
closes #57 add dropdown to navbar for categories

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,4 +19,4 @@
 
 $(document).ready(function() {
   $(".dropdown-button").dropdown({ hover: false });
-})
+});

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,3 +16,7 @@
 //= require jquery-ui/accordion
 //= require turbolinks
 //= require_tree .
+
+$(document).ready(function() {
+  $(".dropdown-button").dropdown({ hover: false });
+})

--- a/app/assets/stylesheets/_custom.scss
+++ b/app/assets/stylesheets/_custom.scss
@@ -339,6 +339,23 @@ nav ul a:hover {
   color: $base-light-blue-light;
 }
 
+.dropdown-content li {
+
+  &:hover {
+    background: $light-grey;
+  }
+
+  a {
+    color: $base-purple-blue-dark;
+
+    &:hover {
+      color: $base-green;
+    }
+
+  }
+
+}
+
 // -----DASHBOARD-----
 
 .user-action-links {

--- a/app/assets/stylesheets/_custom.scss
+++ b/app/assets/stylesheets/_custom.scss
@@ -356,6 +356,23 @@ nav ul a:hover {
 
 }
 
+.mobile-menu-dropdown li {
+  background: $base-purple-blue;
+  height: 40px;
+
+
+  a {
+    color: $white;
+    text-align: left;
+
+    &:hover {
+      color: $base-green;
+    }
+
+  }
+
+}
+
 // -----DASHBOARD-----
 
 .user-action-links {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   helper_method :current_user
   helper_method :current_platform_admin?
   helper_method :current_lister?
+  helper_method :all_categories
 
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
@@ -18,5 +19,9 @@ class ApplicationController < ActionController::Base
 
   def sanitize_price(price)
     price.to_s.gsub!(/[,$]/, "").to_i
+  end
+
+  def all_categories
+    @all_categories ||= Category.all
   end
 end

--- a/app/views/layouts/_home_content.html.erb
+++ b/app/views/layouts/_home_content.html.erb
@@ -17,3 +17,4 @@
       <%= select_tag :categories, options_from_collection_for_select(@categories, "id", "name"), class: "category-select" %>
     </div>
   </div>
+</div>

--- a/app/views/layouts/_javascripts.html.erb
+++ b/app/views/layouts/_javascripts.html.erb
@@ -1,3 +1,1 @@
-<%= javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.5/js/materialize.min.js" %>
-<%= javascript_include_tag "https://code.jquery.com/jquery-2.1.1.min.js" %>
 <%= javascript_include_tag "application", media: "all" %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,3 +1,8 @@
+<ul id="category-nav-dropdown" class="dropdown-content">
+  <% all_categories.each do |category| %>
+    <li><%= link_to category.name, category_path(category) %></li>
+  <% end %>
+</ul>
 <div class="navbar-fixed">
   <nav>
     <div class="nav-wrapper" >
@@ -27,6 +32,11 @@
         <% else %>
           <li><%= link_to "Login", login_path %></li>
         <% end %>
+
+        <!-- Dropdown Trigger -->
+        <li><a class="dropdown-button" href="#" data-activates="category-nav-dropdown">Jump to Category<i class="material-icons right">arrow_drop_down</i></a></li>
+
+
       </ul>
 
       <!-- MOBILE NAV -->

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -3,6 +3,13 @@
     <li><%= link_to category.name, category_path(category) %></li>
   <% end %>
 </ul>
+
+<ul id="category-nav-mobile-dropdown" class="dropdown-content mobile-menu-dropdown">
+  <% all_categories.each do |category| %>
+    <li><%= link_to category.name, category_path(category) %></li>
+  <% end %>
+</ul>
+
 <div class="navbar-fixed">
   <nav>
     <div class="nav-wrapper" >
@@ -35,8 +42,6 @@
 
         <!-- Dropdown Trigger -->
         <li><a class="dropdown-button" href="#" data-activates="category-nav-dropdown">Jump to Category<i class="material-icons right">arrow_drop_down</i></a></li>
-
-
       </ul>
 
       <!-- MOBILE NAV -->
@@ -57,6 +62,9 @@
         <% else %>
           <li><%= link_to "Login", login_path %></li>
         <% end %>
+
+        <!-- Dropdown Trigger -->
+        <li><a class="dropdown-button" href="#" data-activates="category-nav-mobile-dropdown">Jump to Category<i class="material-icons right">arrow_drop_down</i></a></li>
       </ul>
     </div>
   </nav>


### PR DESCRIPTION
Add a dropdown for jumping directly to a category both to the regular navbar and the mobile navbar.

This branch also fixes an issue I discovered where we were double-loading jQuery and the Materialize Javascript. This was happening because we were using both the manifest file (application.js) to load it AND loading it via a javascript_include_tag in the _javascripts partial. Removing the duplication in the partial fixed an issue I was having with the navbar.
