### PR TITLE
Closes #76 Revert bid duration_estimate to # of days integer

### DIFF
--- a/app/assets/stylesheets/_custom.scss
+++ b/app/assets/stylesheets/_custom.scss
@@ -174,20 +174,6 @@ button.stripe-button-el span {
 
 }
 
-.duration-select {
-  margin-bottom: 13px;
-  width: 250px;
-  height: 30px;
-}
-
-#bid_duration_estimate {
-  font-size: 14px;
-}
-
-.duration-label {
-  font-size: 15px;
-}
-
 .back-to-category-link {
   @include main-link;
   font-size: 20px;

--- a/app/controllers/user/jobs_controller.rb
+++ b/app/controllers/user/jobs_controller.rb
@@ -1,19 +1,6 @@
 class User::JobsController < ApplicationController
-  before_action :set_duration_tags, only: [:show]
-
   def show
     @user = User.find_by_slug(params[:user_slug])
     @job = Job.find(params[:id])
-  end
-
-  private
-
-  def set_duration_tags
-    @duration_tags = [
-      ["Short (1 week or less)", 0],
-      ["Medium (1 - 4 weeks)", 1],
-      ["Long (Longer than 4 weeks)", 2],
-      ["Event (Specific date & time)", 3]
-    ]
   end
 end

--- a/app/models/bid.rb
+++ b/app/models/bid.rb
@@ -7,13 +7,14 @@ class Bid < ActiveRecord::Base
   validates :price, presence: true,
                     numericality: { only_integer: true,
                                     greater_than: 0 }
-  validates :duration_estimate, presence: true
+  validates :duration_estimate, presence: true,
+                                numericality: { only_integer: true,
+                                                greater_than: 0 }
   validates :details, presence: true,
                       length: { in: 35..400 }
   validates :status, presence: true
 
   enum status: %w(pending accepted rejected)
-  enum duration_estimate: %w(short medium long event)
 
   scope :accepted_bid, -> { where(status: 1) }
 end

--- a/app/views/user/jobs/show.html.erb
+++ b/app/views/user/jobs/show.html.erb
@@ -57,17 +57,18 @@
                 <%= f.label "Joseph Perry", class: "bidder-name" %>
               </div>
               <div class="col s12 m3 bid-input-field valign">
-                <%= f.number_field :price, placeholder: :price %>
+                <%= f.number_field :price, min: 1, placeholder: "Price in USD" %>
               </div>
-              <div class="col s12 m5 bid-input-field valign center-align">
-                <%= f.label :duration_estimate, class: "duration-label" %>
-                <%= f.select :duration_estimate, options_for_select(@duration_tags), {},
-                class: "duration-select" %>
+              <div class="col s7 m3 bid-input-field valign">
+                <%= f.number_field :duration_estimate, min: 1, placeholder: "Duration Estimate" %>
+              </div>
+              <div class="col s5 m2 bid-input-field valign">
+                <%= label_tag :days %>
               </div>
             </div>
             <div class="row no-bottom-margin center-align valign-wrapper">
               <div class="col s12 m8 valign">
-                <%= f.text_area :details, placeholder: "Leave a comment for the job lister",
+                <%= f.text_area :comment, placeholder: "Leave a comment for the job lister",
                                           class: "bid-comment" %>
               </div>
               <div class="col s12 m4 valign">

--- a/app/views/user/jobs/show.html.erb
+++ b/app/views/user/jobs/show.html.erb
@@ -68,7 +68,7 @@
             </div>
             <div class="row no-bottom-margin center-align valign-wrapper">
               <div class="col s12 m8 valign">
-                <%= f.text_area :comment, placeholder: "Leave a comment for the job lister",
+                <%= f.text_area :details, placeholder: "Leave a comment for the job lister",
                                           class: "bid-comment" %>
               </div>
               <div class="col s12 m4 valign">

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -156,7 +156,7 @@ class Seed
         contractor.bids.create!(
           job_id: rand(1..100),
           price: (i + 1) * rand(1..100),
-          duration_estimate: rand(0..3),
+          duration_estimate: rand(1..60),
           details: Faker::Lorem.characters(100),
           status: 0
         )

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
 
   factory :bid do
     price
-    duration_estimate 1
+    duration_estimate 3
     details Faker::Lorem.characters(40)
     status "pending"
     association :user, factory: :contractor

--- a/test/models/bid_test.rb
+++ b/test/models/bid_test.rb
@@ -8,12 +8,6 @@ class BidTest < ActiveSupport::TestCase
   should validate_presence_of(:details)
   should validate_presence_of(:status)
 
-  test "default bid status is pending" do
-    bid = create(:bid)
-
-    assert_equal "pending", bid.status
-  end
-
   test "contractor can bid on a job" do
     bid = create(:bid)
 
@@ -74,6 +68,31 @@ class BidTest < ActiveSupport::TestCase
     refute bid.valid?
 
     bid.update_attribute(:price, "160,000")
+    refute bid.valid?
+  end
+
+  test "duration estimate (in days) must be a positive number" do
+    bid = create(:bid)
+
+    bid.update_attribute(:duration_estimate, 1)
+    assert bid.valid?
+
+    bid.update_attribute(:duration_estimate, 1.5)
+    refute bid.valid?
+
+    bid.update_attribute(:duration_estimate, 0)
+    refute bid.valid?
+
+    bid.update_attribute(:duration_estimate, -1)
+    refute bid.valid?
+
+    bid.update_attribute(:duration_estimate, "fff")
+    refute bid.valid?
+
+    bid.update_attribute(:duration_estimate, "$123")
+    refute bid.valid?
+
+    bid.update_attribute(:duration_estimate, "160,000")
     refute bid.valid?
   end
 end


### PR DESCRIPTION
We mistakenly converted the Bid class's duration_estimate to be
an enum similar to the Job class's duration_estimate, but this wasn't
what we really wanted. This branch converts it back to an integer,
where we have agreed that the integer will stand for the number of
days the contractor estimates it will take them to complete the job.
Validations and tests were added for this.
