### PR TITLE
closes #46 lister can edit profile fix

### DIFF
--- a/app/controllers/user/users_controller.rb
+++ b/app/controllers/user/users_controller.rb
@@ -31,7 +31,7 @@ class User::UsersController < ApplicationController
 
   def update
     if @user.update_attributes(user_params)
-      if current_user.admin?
+      if current_user.platform_admin?
         redirect_to admin_dashboard_path
       else
         redirect_to dashboard_path

--- a/app/views/user/users/_form.html.erb
+++ b/app/views/user/users/_form.html.erb
@@ -10,11 +10,9 @@
   <br>
 
   <div class="row">
-    <% if current_lister? %>
-    <%= f.label "Upload Profile Picture" %>
+    <%= f.label :file_upload %>
     <br><br>
     <%= f.file_field :file_upload, class: "grey-text" %>
-    <% end %>
   </div>
 
   <%= f.label :email_address %>
@@ -46,11 +44,6 @@
     <%= f.text_field :username  %>
   <% end %>
   <br>
-
-  <%= f.label :file_upload %>
-  <br><br>
-  <%= f.file_field :file_upload, class: "upload_file grey-text" %>
-  <br><br>
 
   <%= f.label :password %>
   <%= f.password_field :password %>

--- a/test/integration/lister_can_edit_profile_test.rb
+++ b/test/integration/lister_can_edit_profile_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+class ListerCanEditProfileTest < ActionDispatch::IntegrationTest
+  test "lister can edit profile" do
+    lister = create(:lister)
+    original_lister = lister.dup
+    visit root_path
+    
+    within("#nav-mobile") do
+      click_on "Login"
+    end
+    fill_in "Username", with: lister.username
+    fill_in "Password", with: lister.password
+    within(".profile-form") do
+      click_on "Login"
+    end
+
+    assert_equal dashboard_path, current_path
+    assert page.has_content?(lister.first_name)
+    assert page.has_content?(lister.last_name)
+    assert page.has_content?(lister.email_address)
+    assert page.has_content?(lister.street_address)
+    assert page.has_content?(lister.city)
+    assert page.has_content?(lister.state)
+    assert page.has_content?(lister.zipcode)
+    assert page.has_content?(lister.bio)
+    click_on "Edit Profile"
+
+    assert edit_user_path(lister), current_path
+    fill_in "First name", with: "new_first_name"
+    fill_in "Last name", with: "new_last_name"
+    fill_in "Email address", with: "new_email_address@example.com"
+    fill_in "Street address", with: "new_street_address"
+    fill_in "City", with: "new_city"
+    select "Washington", from: "user_state"
+    fill_in "Zipcode", with: 22222
+    fill_in "Bio", with: "new_bio"
+    fill_in "Password", with: "new_password"
+    fill_in "Password confirmation", with: "new_password"
+    click_on "Update User"
+
+    lister.reload
+    assert_equal dashboard_path, current_path
+    assert page.has_content?(lister.first_name)
+    assert page.has_content?(lister.last_name)
+    assert page.has_content?(lister.email_address)
+    assert page.has_content?(lister.street_address)
+    assert page.has_content?(lister.city)
+    assert page.has_content?(lister.state)
+    assert page.has_content?(lister.zipcode)
+    assert page.has_content?(lister.bio)
+    refute page.has_content?(original_lister.first_name)
+    refute page.has_content?(original_lister.last_name)
+    refute page.has_content?(original_lister.email_address)
+    refute page.has_content?(original_lister.street_address)
+    refute page.has_content?(original_lister.city)
+    refute page.has_content?(original_lister.state)
+    refute page.has_content?(original_lister.zipcode)
+    refute page.has_content?(original_lister.bio)
+  end
+
+  test "only contractors editing their profile see the role dropdown" do
+    skip
+  end
+
+  def fixture_image_path
+    Rails.root.join("test", "helpers", "test_image.jpg")
+  end
+end

--- a/test/integration/lister_can_edit_profile_test.rb
+++ b/test/integration/lister_can_edit_profile_test.rb
@@ -5,13 +5,13 @@ class ListerCanEditProfileTest < ActionDispatch::IntegrationTest
     lister = create(:lister)
     original_lister = lister.dup
     visit root_path
-    
-    within("#nav-mobile") do
+
+    within "#nav-mobile" do
       click_on "Login"
     end
     fill_in "Username", with: lister.username
     fill_in "Password", with: lister.password
-    within(".profile-form") do
+    within ".profile-form" do
       click_on "Login"
     end
 
@@ -33,7 +33,7 @@ class ListerCanEditProfileTest < ActionDispatch::IntegrationTest
     fill_in "Street address", with: "new_street_address"
     fill_in "City", with: "new_city"
     select "Washington", from: "user_state"
-    fill_in "Zipcode", with: 22222
+    fill_in "Zipcode", with: 22_222
     fill_in "Bio", with: "new_bio"
     fill_in "Password", with: "new_password"
     fill_in "Password confirmation", with: "new_password"
@@ -59,8 +59,52 @@ class ListerCanEditProfileTest < ActionDispatch::IntegrationTest
     refute page.has_content?(original_lister.bio)
   end
 
-  test "only contractors editing their profile see the role dropdown" do
-    skip
+  test "listers editing profile may not change role" do
+    contractor = create(:contractor)
+    lister = create(:lister)
+    visit root_path
+
+    within "#nav-mobile" do
+      click_on "Login"
+    end
+    fill_in "Username", with: contractor.username
+    fill_in "Password", with: contractor.password
+    within ".profile-form" do
+      click_on "Login"
+    end
+
+    assert_equal dashboard_path, current_path
+    assert page.has_content?(contractor.first_name)
+    assert page.has_content?(contractor.last_name)
+    click_on "Edit Profile"
+
+    assert edit_user_path(contractor), current_path
+    within ".profile-form" do
+      assert page.has_select?("Role", options: ["contractor", "lister"])
+    end
+    within "#nav-mobile" do
+      click_on "Logout"
+    end
+
+    assert_equal root_path, current_path
+    within "#nav-mobile" do
+      click_on "Login"
+    end
+    fill_in "Username", with: lister.username
+    fill_in "Password", with: lister.password
+    within ".profile-form" do
+      click_on "Login"
+    end
+
+    assert_equal dashboard_path, current_path
+    assert page.has_content?(lister.first_name)
+    assert page.has_content?(lister.last_name)
+    click_on "Edit Profile"
+
+    assert edit_user_path(lister), current_path
+    within ".profile-form" do
+      assert page.has_select?("Role", options: ["lister"])
+    end
   end
 
   def fixture_image_path

--- a/test/integration/user_can_edit_profile_test.rb
+++ b/test/integration/user_can_edit_profile_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class ListerCanEditProfileTest < ActionDispatch::IntegrationTest
+class UserCanEditProfileTest < ActionDispatch::IntegrationTest
   test "lister can edit profile" do
     lister = create(:lister)
     original_lister = lister.dup
@@ -60,33 +60,9 @@ class ListerCanEditProfileTest < ActionDispatch::IntegrationTest
   end
 
   test "listers editing profile may not change role" do
-    contractor = create(:contractor)
     lister = create(:lister)
     visit root_path
 
-    within "#nav-mobile" do
-      click_on "Login"
-    end
-    fill_in "Username", with: contractor.username
-    fill_in "Password", with: contractor.password
-    within ".profile-form" do
-      click_on "Login"
-    end
-
-    assert_equal dashboard_path, current_path
-    assert page.has_content?(contractor.first_name)
-    assert page.has_content?(contractor.last_name)
-    click_on "Edit Profile"
-
-    assert edit_user_path(contractor), current_path
-    within ".profile-form" do
-      assert page.has_select?("Role", options: ["contractor", "lister"])
-    end
-    within "#nav-mobile" do
-      click_on "Logout"
-    end
-
-    assert_equal root_path, current_path
     within "#nav-mobile" do
       click_on "Login"
     end
@@ -105,6 +81,33 @@ class ListerCanEditProfileTest < ActionDispatch::IntegrationTest
     within ".profile-form" do
       assert page.has_select?("Role", options: ["lister"])
     end
+  end
+
+  test "contractors editing profile may change role" do
+    contractor = create(:contractor)
+    visit root_path
+
+    within "#nav-mobile" do
+      click_on "Login"
+    end
+    fill_in "Username", with: contractor.username
+    fill_in "Password", with: contractor.password
+    within ".profile-form" do
+      click_on "Login"
+    end
+
+    assert_equal dashboard_path, current_path
+    assert page.has_content?(contractor.first_name)
+    assert page.has_content?(contractor.last_name)
+    click_on "Edit Profile"
+
+    assert edit_user_path(contractor), current_path
+
+    select "lister", from: "Role"
+    click_on "Update User"
+    contractor.reload
+    assert_equal dashboard_path, current_path
+    assert_equal "lister", contractor.role
   end
 
   def fixture_image_path

--- a/test/integration/user_can_edit_profile_test.rb
+++ b/test/integration/user_can_edit_profile_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class ListerCanEditProfileTest < ActionDispatch::IntegrationTest
+class UserCanEditProfileTest < ActionDispatch::IntegrationTest
   test "lister can edit profile" do
     lister = create(:lister)
     original_lister = lister.dup
@@ -60,33 +60,9 @@ class ListerCanEditProfileTest < ActionDispatch::IntegrationTest
   end
 
   test "listers editing profile may not change role" do
-    contractor = create(:contractor)
     lister = create(:lister)
     visit root_path
 
-    within "#nav-mobile" do
-      click_on "Login"
-    end
-    fill_in "Username", with: contractor.username
-    fill_in "Password", with: contractor.password
-    within ".profile-form" do
-      click_on "Login"
-    end
-
-    assert_equal dashboard_path, current_path
-    assert page.has_content?(contractor.first_name)
-    assert page.has_content?(contractor.last_name)
-    click_on "Edit Profile"
-
-    assert edit_user_path(contractor), current_path
-    within ".profile-form" do
-      assert page.has_select?("Role", options: ["contractor", "lister"])
-    end
-    within "#nav-mobile" do
-      click_on "Logout"
-    end
-
-    assert_equal root_path, current_path
     within "#nav-mobile" do
       click_on "Login"
     end
@@ -105,6 +81,33 @@ class ListerCanEditProfileTest < ActionDispatch::IntegrationTest
     within ".profile-form" do
       assert page.has_select?("Role", options: ["lister"])
     end
+  end
+
+  test "contractors editing profile may change role" do
+    contractor = create(:contractor)
+    visit root_path
+
+    within "#nav-mobile" do
+      click_on "Login"
+    end
+    fill_in "Username", with: contractor.username
+    fill_in "Password", with: contractor.password
+    within ".profile-form" do
+      click_on "Login"
+    end
+
+    assert_equal dashboard_path, current_path
+    assert page.has_content?(contractor.first_name)
+    assert page.has_content?(contractor.last_name)
+    click_on "Edit Profile"
+
+    assert edit_user_path(contractor), current_path
+
+    select "lister", :from => "Role"
+    click_on "Update User"
+    contractor.reload
+    assert_equal dashboard_path, current_path
+    assert_equal "lister", contractor.role
   end
 
   def fixture_image_path


### PR DESCRIPTION
Closes #46 
Closes #45 
- Feature testing for user profile edit
- Fixed minor error with .admin? call in users_controller.rb
- Removed extraneous file field, labeled persisting file field
- Included contractor role edit in test
