### PR TITLE
Closes #117 Remove Unnecessary Classes in Dashboard

### DIFF
--- a/app/views/user/users/_bid_table.html.erb
+++ b/app/views/user/users/_bid_table.html.erb
@@ -16,7 +16,7 @@
   </thead>
   <tbody>
       <% user.bids.each do |bid| %>
-        <tr>
+        <tr class="bid">
           <td><%= link_to bid.job.id, user_job_path(bid.job.lister, bid.job) %></td>
           <td><%= link_to bid.job.title, user_job_path(bid.job.lister, bid.job) %></td>
           <td class="bid-status status-<%= bid.status %>"><%= bid.status %></td>

--- a/app/views/user/users/_bid_table.html.erb
+++ b/app/views/user/users/_bid_table.html.erb
@@ -16,7 +16,7 @@
   </thead>
   <tbody>
       <% user.bids.each do |bid| %>
-        <tr class="bid-<%= bid.id %>">
+        <tr>
           <td><%= link_to bid.job.id, user_job_path(bid.job.lister, bid.job) %></td>
           <td><%= link_to bid.job.title, user_job_path(bid.job.lister, bid.job) %></td>
           <td class="bid-status status-<%= bid.status %>"><%= bid.status %></td>

--- a/app/views/user/users/_listing_table.html.erb
+++ b/app/views/user/users/_listing_table.html.erb
@@ -25,7 +25,7 @@
     </thead>
     <tbody>
       <% user.jobs.each do |listing| %>
-        <tr>
+        <tr class="listing">
           <td><%= link_to listing.id, user_job_path(user, listing) %></td>
           <td><%= link_to listing.title, user_job_path(user, listing) %></td>
 

--- a/app/views/user/users/_listing_table.html.erb
+++ b/app/views/user/users/_listing_table.html.erb
@@ -25,7 +25,7 @@
     </thead>
     <tbody>
       <% user.jobs.each do |listing| %>
-        <tr class="listing-<%= listing.id %>">
+        <tr>
           <td><%= link_to listing.id, user_job_path(user, listing) %></td>
           <td><%= link_to listing.title, user_job_path(user, listing) %></td>
 

--- a/test/integration/contractor_views_dashboard_test.rb
+++ b/test/integration/contractor_views_dashboard_test.rb
@@ -32,7 +32,7 @@ class ContractorViewsDashboardTest < ActionDispatch::IntegrationTest
       assert page.has_content?("My Bids")
     end
 
-    within(".bid-#{bid1.id}") do
+    within("tbody tr:nth-child(1)") do
       assert page.has_link?(job1.id, href: user_job_path(job1.lister, job1))
       assert page.has_link?(job1.title, href: user_job_path(job1.lister, job1))
       assert page.has_content?(bid1.status)

--- a/test/integration/lister_completes_job_test.rb
+++ b/test/integration/lister_completes_job_test.rb
@@ -10,7 +10,7 @@ class ListerCompletesJobTest < ActionDispatch::IntegrationTest
     visit dashboard_path
     click_on "My Listings"
 
-    within(".listing-#{job.id}") do
+    within("#my-listings tbody tr:nth-child(1)") do
       click_on "Complete"
     end
 

--- a/test/integration/lister_views_dashboard_test.rb
+++ b/test/integration/lister_views_dashboard_test.rb
@@ -50,7 +50,7 @@ class ListerViewsDashboardTest < ActionDispatch::IntegrationTest
       assert page.has_content?("My Bids")
     end
 
-    within(".bid-#{bid1.id}") do
+    within("#my-bids tbody tr:nth-child(1)") do
       assert page.has_link?(job_lister_bid_on.id,
                             href: user_job_path(job_lister_bid_on.lister,
                                                 job_lister_bid_on))
@@ -81,7 +81,7 @@ class ListerViewsDashboardTest < ActionDispatch::IntegrationTest
       assert page.has_select?("job_status", options: job_statuses)
     end
 
-    within(".listing-#{open_bid_job.id}") do
+    within("#my-listings tbody tr:nth-child(1)") do
       assert page.has_link?(open_bid_job.id,
                             href: user_job_path(open_bid_job.lister,
                                                 open_bid_job))
@@ -99,7 +99,7 @@ class ListerViewsDashboardTest < ActionDispatch::IntegrationTest
       assert_equal "", find(".contractor").text
     end
 
-    within(".listing-#{closed_bid_job.id}") do
+    within("#my-listings tbody tr:nth-child(2)") do
       assert page.has_link?(closed_bid_job.id,
                             href: user_job_path(closed_bid_job.lister,
                                                 closed_bid_job))
@@ -120,7 +120,7 @@ class ListerViewsDashboardTest < ActionDispatch::IntegrationTest
       assert_equal "", find(".contractor").text
     end
 
-    within(".listing-#{in_progress_job.id}") do
+    within("#my-listings tbody tr:nth-child(3)") do
       assert page.has_link?(in_progress_job.id,
                             href: user_job_path(in_progress_job.lister,
                                                 in_progress_job))
@@ -138,7 +138,7 @@ class ListerViewsDashboardTest < ActionDispatch::IntegrationTest
       assert page.has_content?(accepted_bid1.user.full_name)
     end
 
-    within(".listing-#{completed_job.id}") do
+    within("#my-listings tbody tr:nth-child(4)") do
       assert page.has_link?(completed_job.id,
                             href: user_job_path(completed_job.lister,
                                                 completed_job))
@@ -152,7 +152,7 @@ class ListerViewsDashboardTest < ActionDispatch::IntegrationTest
       assert page.has_content?(accepted_bid2.user.full_name)
     end
 
-    within(".listing-#{cancelled_job.id}") do
+    within("#my-listings tbody tr:nth-child(5)") do
       assert page.has_link?(cancelled_job.id,
                             href: user_job_path(cancelled_job.lister,
                                                 cancelled_job))


### PR DESCRIPTION
Removed scoping classes for bid and listing table rows associated with their ids. They were not being used; corrected tests to refer to nth child of the table instead.
